### PR TITLE
Add configurable topic prefix

### DIFF
--- a/mqtt-forward.c
+++ b/mqtt-forward.c
@@ -246,7 +246,7 @@ static void *tcp_session_rx_thread_fn(void *arg)
 				retransmit_tx_hdr->flags = 0;
 			}
 
-			DBG_LOG_("Session %s: TX RETRANSMIT: %4llu. Acked %4llu\n",
+			DBG_LOG_("Session %s: TX RETRANSMIT: %4lu. Acked %4lu\n",
 				 session_data->session_id,
 				 retransmit_tx_hdr->seq_nbr,
 				 retransmit_tx_hdr->acked_seq_nbr);
@@ -276,7 +276,7 @@ static void *tcp_session_rx_thread_fn(void *arg)
 					tx_hdr.acked_seq_nbr =
 						rx_backlog->expected_seq_nbr - 1;
 				}
-				DBG_LOG_("Session %s: TX HEARTBEAT: %4llu. Acked %4llu\n",
+				DBG_LOG_("Session %s: TX HEARTBEAT: %4lu. Acked %4lu\n",
 					 session_data->session_id,
 					 tx_hdr.seq_nbr,
 					 tx_hdr.acked_seq_nbr);
@@ -335,7 +335,7 @@ static void *tcp_session_rx_thread_fn(void *arg)
 			tx_backlog->backlog[backlog_write_idx].len = recv_len;
 			memcpy(tx_backlog->backlog[backlog_write_idx].buf, rx_buf, recv_len);
 			session_data->tx_seq_nbr++;
-			DBG_LOG_("Session %s: TX: %4llu. Acked %4llu\n",
+			DBG_LOG_("Session %s: TX: %4lu. Acked %4lu\n",
 				 session_data->session_id,
 				 tx_hdr.seq_nbr,
 				 tx_hdr.acked_seq_nbr);
@@ -461,7 +461,7 @@ static int create_session(const char *session_id,
 	fprintf(stderr, "%s: Creating session thread for session %s, session number %lu\n",
 		 __func__,
 		 tcp_sessions[session_nbr_local].session_id,
-		 (long unsigned int) session_nbr_local);
+		 session_nbr_local);
 	ret = pthread_create(&tcp_rx_threads[session_nbr_local],
 			     NULL,
 			     &tcp_session_rx_thread_fn,
@@ -709,12 +709,12 @@ static void handle_mqtt_message(uint8_t *msg,
 	tx_backlog = &tcp_sessions[session_nbr].tx_backlog;
 
 	if (rx_hdr->flags & TCP_OVER_MQTT_FLAG_ACKED_SEQ_NBR)
-		DBG_LOG_("Session %s: RX: %4llu. Remote acked %4llu\n",
+		DBG_LOG_("Session %s: RX: %4lu. Remote acked %4lu\n",
 			 tcp_sessions[session_nbr].session_id,
 			 rx_hdr->seq_nbr,
 			 rx_hdr->acked_seq_nbr);
 	else
-		DBG_LOG_("Session %s: RX: %4llu. No remote ack\n",
+		DBG_LOG_("Session %s: RX: %4lu. No remote ack\n",
 			 tcp_sessions[session_nbr].session_id,
 			 rx_hdr->seq_nbr);
 
@@ -767,7 +767,7 @@ static void handle_mqtt_message(uint8_t *msg,
 
 	if (backlog_offset < 0) {
 		fprintf(stderr, "%s: backlog offset is negative! Corrupt input data?\n", __func__);
-		fprintf(stderr, "RX sequence number: %4llu\n",
+		fprintf(stderr, "RX sequence number: %4lu\n",
 			rx_hdr->seq_nbr);
 		return;
 	}
@@ -777,7 +777,7 @@ static void handle_mqtt_message(uint8_t *msg,
 		/* A packet is probably lost :(
 		 * move forward in the backlog until a valid packet is found */
 		while (!rx_backlog->backlog[rx_backlog->read_idx].buf) {
-			fprintf(stderr, "%s: Packet %llu dropped!\n",
+			fprintf(stderr, "%s: Packet %ld dropped!\n",
 				__func__,
 				rx_backlog->expected_seq_nbr);
 			rx_backlog->expected_seq_nbr++;

--- a/mqtt-forward.c
+++ b/mqtt-forward.c
@@ -34,6 +34,7 @@
 #define ENV_VAR_ROOT_CA     "MQTT_FORWARD_ROOT_CA"
 #define ENV_VAR_CERTIFICATE "MQTT_FORWARD_CERTIFICATE"
 #define ENV_VAR_PRIVATE_KEY "MQTT_FORWARD_PRIVATE_KEY"
+#define ENV_VAR_PREFIX      "MQTT_FORWARD_PREFIX"
 
 struct packet_backlog_data {
 	uint8_t *buf;
@@ -110,6 +111,7 @@ static char mqtt_host[100];
 static char mqtt_root_ca[100];
 static char mqtt_certificate[100];
 static char mqtt_private_key[100];
+static char mqtt_prefix[100];
 static char tcp_server_addr[100];
 
 static void clear_rx_packet_backlog(struct rx_packet_backlog *rx_backlog)
@@ -415,7 +417,8 @@ static int create_session(const char *session_id,
 
 		snprintf(topic,
 			 sizeof(topic),
-			 "ssh/%s/%s/rx",
+			 "%s/%s/%s/rx",
+			 mqtt_prefix,
 			 server_mqtt_id,
 			 session_id_local);
 
@@ -443,13 +446,15 @@ static int create_session(const char *session_id,
 	if (server_session)
 		snprintf(tcp_sessions[session_nbr_local].publish_topic,
 			 200,
-			 "ssh/%s/%s/rx",
+			 "%s/%s/%s/rx",
+			 mqtt_prefix,
 			 server_mqtt_id,
 			 session_id_local);
 	else
 		snprintf(tcp_sessions[session_nbr_local].publish_topic,
 			 200,
-			 "ssh/%s/%s/tx",
+			 "%s/%s/%s/tx",
+			 mqtt_prefix,
 			 server_mqtt_id,
 			 session_id_local);
 
@@ -547,7 +552,7 @@ static void *beacon_tx_thread_fn(void *arg)
 	struct tcp_over_mqtt_hdr msg_hdr = {.flags = TCP_OVER_MQTT_FLAG_BEACON};
 	char topic[200];
 
-	snprintf(topic, sizeof(topic), "ssh/%s/beacon/rx", server_mqtt_id);
+	snprintf(topic, sizeof(topic), "%s/%s/beacon/rx", mqtt_prefix, server_mqtt_id);
 
 	for (;;) {
 		if (!connected_to_mqtt_server) {
@@ -913,7 +918,8 @@ static void on_connect(struct mosquitto *mosq, void *obj, int rc)
 	if (server_mode) {
 		snprintf(topic,
 			 200,
-			 "ssh/%s/+/tx",
+			 "%s/%s/+/tx",
+			 mqtt_prefix,
 			 server_mqtt_id);
 
 		ret = mosquitto_subscribe(g_mqtt_client,
@@ -928,7 +934,8 @@ static void on_connect(struct mosquitto *mosq, void *obj, int rc)
 	} else if (list_servers) {
 		snprintf(topic,
 			 200,
-			 "ssh/+/beacon/rx");
+			 "%s/+/beacon/rx",
+			 mqtt_prefix);
 
 		ret = mosquitto_subscribe(g_mqtt_client,
 					  &mid,
@@ -1162,6 +1169,7 @@ int main(int argc, char **argv)
 		{"mqtt-certificate", 1, 0, 1003},
 		{"mqtt-private-key", 1, 0, 1004},
 		{"mqtt-qos", 1, 0, 1007},
+        {"mqtt-prefix", 1, 0, 1008},
 		{0, 0, 0, 0}
 	};
 	int port = 22;
@@ -1176,6 +1184,8 @@ int main(int argc, char **argv)
 	bool tcp_server_addr_set = false;;
 	bool mqtt_qos_set = false;
 	char *env_var;
+
+	strcpy(mqtt_prefix, "ssh");
 
 	/* Check environment variables before reading command line options*/
 	if ((env_var = getenv(ENV_VAR_MQTT_HOST))) {
@@ -1196,6 +1206,9 @@ int main(int argc, char **argv)
 		strcpy(mqtt_private_key, env_var);
 		mqtt_private_key_set = true;
 		use_tls = true;
+	}
+	if ((env_var = getenv(ENV_VAR_PREFIX))) {
+		strcpy(mqtt_prefix, env_var);
 	}
 
 	while ((c = getopt_long(argc, argv, "hdtslba:p:", long_options, &option_index)) != -1) {
@@ -1254,6 +1267,9 @@ int main(int argc, char **argv)
 		case 1007:
 			mqtt_qos = strtol(optarg, NULL, 10);
 			mqtt_qos_set = true;
+			break;
+		case 1008:
+			strcpy(mqtt_prefix, optarg);
 			break;
 		case 'h':
 		default:

--- a/mqtt-forward.c
+++ b/mqtt-forward.c
@@ -244,7 +244,7 @@ static void *tcp_session_rx_thread_fn(void *arg)
 				retransmit_tx_hdr->flags = 0;
 			}
 
-			DBG_LOG_("Session %s: TX RETRANSMIT: %4lu. Acked %4lu\n",
+			DBG_LOG_("Session %s: TX RETRANSMIT: %4llu. Acked %4llu\n",
 				 session_data->session_id,
 				 retransmit_tx_hdr->seq_nbr,
 				 retransmit_tx_hdr->acked_seq_nbr);
@@ -274,7 +274,7 @@ static void *tcp_session_rx_thread_fn(void *arg)
 					tx_hdr.acked_seq_nbr =
 						rx_backlog->expected_seq_nbr - 1;
 				}
-				DBG_LOG_("Session %s: TX HEARTBEAT: %4lu. Acked %4lu\n",
+				DBG_LOG_("Session %s: TX HEARTBEAT: %4llu. Acked %4llu\n",
 					 session_data->session_id,
 					 tx_hdr.seq_nbr,
 					 tx_hdr.acked_seq_nbr);
@@ -333,7 +333,7 @@ static void *tcp_session_rx_thread_fn(void *arg)
 			tx_backlog->backlog[backlog_write_idx].len = recv_len;
 			memcpy(tx_backlog->backlog[backlog_write_idx].buf, rx_buf, recv_len);
 			session_data->tx_seq_nbr++;
-			DBG_LOG_("Session %s: TX: %4lu. Acked %4lu\n",
+			DBG_LOG_("Session %s: TX: %4llu. Acked %4llu\n",
 				 session_data->session_id,
 				 tx_hdr.seq_nbr,
 				 tx_hdr.acked_seq_nbr);
@@ -456,7 +456,7 @@ static int create_session(const char *session_id,
 	fprintf(stderr, "%s: Creating session thread for session %s, session number %lu\n",
 		 __func__,
 		 tcp_sessions[session_nbr_local].session_id,
-		 session_nbr_local);
+		 (long unsigned int) session_nbr_local);
 	ret = pthread_create(&tcp_rx_threads[session_nbr_local],
 			     NULL,
 			     &tcp_session_rx_thread_fn,
@@ -704,12 +704,12 @@ static void handle_mqtt_message(uint8_t *msg,
 	tx_backlog = &tcp_sessions[session_nbr].tx_backlog;
 
 	if (rx_hdr->flags & TCP_OVER_MQTT_FLAG_ACKED_SEQ_NBR)
-		DBG_LOG_("Session %s: RX: %4lu. Remote acked %4lu\n",
+		DBG_LOG_("Session %s: RX: %4llu. Remote acked %4llu\n",
 			 tcp_sessions[session_nbr].session_id,
 			 rx_hdr->seq_nbr,
 			 rx_hdr->acked_seq_nbr);
 	else
-		DBG_LOG_("Session %s: RX: %4lu. No remote ack\n",
+		DBG_LOG_("Session %s: RX: %4llu. No remote ack\n",
 			 tcp_sessions[session_nbr].session_id,
 			 rx_hdr->seq_nbr);
 
@@ -762,7 +762,7 @@ static void handle_mqtt_message(uint8_t *msg,
 
 	if (backlog_offset < 0) {
 		fprintf(stderr, "%s: backlog offset is negative! Corrupt input data?\n", __func__);
-		fprintf(stderr, "RX sequence number: %4lu\n",
+		fprintf(stderr, "RX sequence number: %4llu\n",
 			rx_hdr->seq_nbr);
 		return;
 	}
@@ -772,7 +772,7 @@ static void handle_mqtt_message(uint8_t *msg,
 		/* A packet is probably lost :(
 		 * move forward in the backlog until a valid packet is found */
 		while (!rx_backlog->backlog[rx_backlog->read_idx].buf) {
-			fprintf(stderr, "%s: Packet %ld dropped!\n",
+			fprintf(stderr, "%s: Packet %llu dropped!\n",
 				__func__,
 				rx_backlog->expected_seq_nbr);
 			rx_backlog->expected_seq_nbr++;

--- a/mqtt-forward.c
+++ b/mqtt-forward.c
@@ -34,6 +34,7 @@
 #define ENV_VAR_ROOT_CA     "MQTT_FORWARD_ROOT_CA"
 #define ENV_VAR_CERTIFICATE "MQTT_FORWARD_CERTIFICATE"
 #define ENV_VAR_PRIVATE_KEY "MQTT_FORWARD_PRIVATE_KEY"
+#define ENV_VAR_PREFIX      "MQTT_FORWARD_PREFIX"
 
 struct packet_backlog_data {
 	uint8_t *buf;
@@ -110,6 +111,7 @@ static char mqtt_host[100];
 static char mqtt_root_ca[100];
 static char mqtt_certificate[100];
 static char mqtt_private_key[100];
+static char mqtt_prefix[100];
 static char tcp_server_addr[100];
 
 static void clear_rx_packet_backlog(struct rx_packet_backlog *rx_backlog)
@@ -415,7 +417,8 @@ static int create_session(const char *session_id,
 
 		snprintf(topic,
 			 sizeof(topic),
-			 "ssh/%s/%s/rx",
+			 "%s/%s/%s/rx",
+			 mqtt_prefix,
 			 server_mqtt_id,
 			 session_id_local);
 
@@ -443,13 +446,15 @@ static int create_session(const char *session_id,
 	if (server_session)
 		snprintf(tcp_sessions[session_nbr_local].publish_topic,
 			 200,
-			 "ssh/%s/%s/rx",
+			 "%s/%s/%s/rx",
+			 mqtt_prefix,
 			 server_mqtt_id,
 			 session_id_local);
 	else
 		snprintf(tcp_sessions[session_nbr_local].publish_topic,
 			 200,
-			 "ssh/%s/%s/tx",
+			 "%s/%s/%s/tx",
+			 mqtt_prefix,
 			 server_mqtt_id,
 			 session_id_local);
 
@@ -547,7 +552,7 @@ static void *beacon_tx_thread_fn(void *arg)
 	struct tcp_over_mqtt_hdr msg_hdr = {.flags = TCP_OVER_MQTT_FLAG_BEACON};
 	char topic[200];
 
-	snprintf(topic, sizeof(topic), "ssh/%s/beacon/rx", server_mqtt_id);
+	snprintf(topic, sizeof(topic), "%s/%s/beacon/rx", mqtt_prefix, server_mqtt_id);
 
 	for (;;) {
 		if (!connected_to_mqtt_server) {
@@ -913,7 +918,8 @@ static void on_connect(struct mosquitto *mosq, void *obj, int rc)
 	if (server_mode) {
 		snprintf(topic,
 			 200,
-			 "ssh/%s/+/tx",
+			 "%s/%s/+/tx",
+			 mqtt_prefix,
 			 server_mqtt_id);
 
 		ret = mosquitto_subscribe(g_mqtt_client,
@@ -928,7 +934,8 @@ static void on_connect(struct mosquitto *mosq, void *obj, int rc)
 	} else if (list_servers) {
 		snprintf(topic,
 			 200,
-			 "ssh/+/beacon/rx");
+			 "%s/+/beacon/rx",
+			 mqtt_prefix);
 
 		ret = mosquitto_subscribe(g_mqtt_client,
 					  &mid,
@@ -1162,6 +1169,7 @@ int main(int argc, char **argv)
 		{"mqtt-certificate", 1, 0, 1003},
 		{"mqtt-private-key", 1, 0, 1004},
 		{"mqtt-qos", 1, 0, 1007},
+        {"mqtt-prefix", 1, 0, 1008},
 		{0, 0, 0, 0}
 	};
 	int port = 22;
@@ -1176,6 +1184,8 @@ int main(int argc, char **argv)
 	bool tcp_server_addr_set = false;;
 	bool mqtt_qos_set = false;
 	char *env_var;
+
+	strcpy(mqtt_prefix, "ssh");
 
 	/* Check environment variables before reading command line options*/
 	if ((env_var = getenv(ENV_VAR_MQTT_HOST))) {
@@ -1196,6 +1206,9 @@ int main(int argc, char **argv)
 		strcpy(mqtt_private_key, env_var);
 		mqtt_private_key_set = true;
 		use_tls = true;
+	}
+	if ((env_var = getenv(ENV_VAR_PREFIX))) {
+		strcpy(mqtt_prefix, env_var);
 	}
 
 	while ((c = getopt_long(argc, argv, "hdtslba:p:", long_options, &option_index)) != -1) {
@@ -1254,6 +1267,9 @@ int main(int argc, char **argv)
 		case 1007:
 			mqtt_qos = strtol(optarg, NULL, 10);
 			mqtt_qos_set = true;
+			break;
+		case 1008,
+			strcpy(mqtt_prefix, optarg);
 			break;
 		case 'h':
 		default:

--- a/mqtt-forward.c
+++ b/mqtt-forward.c
@@ -1268,7 +1268,7 @@ int main(int argc, char **argv)
 			mqtt_qos = strtol(optarg, NULL, 10);
 			mqtt_qos_set = true;
 			break;
-		case 1008,
+		case 1008:
 			strcpy(mqtt_prefix, optarg);
 			break;
 		case 'h':


### PR DESCRIPTION
The mqtt-forward application currently using the topic prefix of _ssh/_ for messages between client and servers. This PR adds a command-line parameter (_--mqtt-prefix_) and environment variable (_MQTT_FORWARD_PREFIX_) such that this can be topic prefix can be changed. If left unspecified, the current value of ssh will be used.